### PR TITLE
sidebarの固定にposition: stickyを使用

### DIFF
--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -37,18 +37,21 @@ const Styled = styled.div`
 
   .content-wrapper {
     display: flex;
-    height: 100vh;
+    min-height: 100vh;
+  }
+
+  .pc-drawer-container {
+    border-right: 1px solid #efefef;
+    flex-basis: 16%;
   }
 
   .pc-drawer {
-    border-right: 1px solid #efefef;
-    flex-basis: 16%;
     position: sticky;
+    top: 0px;
   }
 
   .content {
     flex-basis: 84%;
-    overflow: scroll;
   }
 
   @media (max-width: ${breakPointMedium}) {
@@ -66,7 +69,7 @@ const Styled = styled.div`
       margin-top: 24px;
     }
 
-    .pc-drawer {
+    .pc-drawer-container {
       display: none;
     }
 
@@ -97,9 +100,11 @@ const Blog: NextPage<Props> = ({ content, blogData }) => {
               <Divider></Divider>
             </div>
             <div className="content-wrapper">
-              <div className="pc-drawer">
-                <DrawerContent></DrawerContent>
-              </div>
+              <aside className="pc-drawer-container">
+                <div className="pc-drawer">
+                  <DrawerContent></DrawerContent>
+                </div>
+              </aside>
               <div className="content">
                 <Layout route={router.route}>
                   <BlogContent


### PR DESCRIPTION
- heightを100vhにしてはみ出した分ををoverflow: scrollにしていたため、capture full screenで全文をキャプチャできなかったのを修正

|  before  |  after  |
| ---- | ---- |
|![localhost_3000_blog_ecspresso-example](https://user-images.githubusercontent.com/26107213/104726334-c8b51480-5776-11eb-84b5-161d2062d591.png)|![localhost_3000_blog_ecspresso-example (1)](https://user-images.githubusercontent.com/26107213/104726377-d36fa980-5776-11eb-83be-b45bade1a32d.png)|