### PR TITLE
Feature pagenation

### DIFF
--- a/src/components/blog-layout.tsx
+++ b/src/components/blog-layout.tsx
@@ -1,0 +1,122 @@
+import { Divider } from '@material-ui/core';
+import MenuIcon from '@material-ui/icons/Menu';
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+import { BlogData } from '../models';
+import { breakPointMedium } from '../styles';
+import { BlogContent } from './blog-content';
+import { DrawerContainer } from './drawer-container';
+import { DrawerContent } from './drawer-content';
+import { Footer } from './footer';
+
+type Props = {
+  content: string;
+  blogData: BlogData;
+};
+
+const Styled = styled.div`
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+  }
+
+  .sp-header {
+    display: none;
+  }
+
+  .drawer-not-sp {
+    width: 240px;
+    flex-shrink: 0;
+  }
+
+  .content-wrapper {
+    display: flex;
+    min-height: 100vh;
+  }
+
+  .pc-drawer-container {
+    border-right: 1px solid #efefef;
+    flex-basis: 16%;
+  }
+
+  .pc-drawer {
+    position: sticky;
+    top: 0px;
+  }
+
+  .content {
+    flex-basis: 84%;
+  }
+
+  @media (max-width: ${breakPointMedium}) {
+    padding: 0 2%;
+
+    .sp-header {
+      display: flex;
+      position: fixed;
+      width: 100%;
+      background: white;
+      z-index: 1;
+    }
+
+    .content-wrapper {
+      margin-top: 24px;
+    }
+
+    .pc-drawer-container {
+      display: none;
+    }
+
+    .content {
+      flex-basis: 100%;
+      overflow: visible;
+      max-width: 100%;
+      word-break: break-word;
+    }
+  }
+`;
+
+export const BlogLayout: React.FC<Props> = ({ content, blogData }) => {
+  const [isSpDrawerOpen, setIsSpDrawerOpen] = useState(false);
+  const changeIsDrawerOpen = useCallback(() => {
+    setIsSpDrawerOpen((prev) => !prev);
+  }, []);
+
+  return (
+    <>
+      <Styled>
+        <DrawerContainer isOpen={isSpDrawerOpen} changeSidenav={changeIsDrawerOpen}>
+          <div className="wrapper">
+            <div className="sp-header">
+              <MenuIcon onClick={changeIsDrawerOpen} fontSize="large"></MenuIcon>
+              <Divider></Divider>
+            </div>
+            <div className="content-wrapper">
+              <aside className="pc-drawer-container">
+                <div className="pc-drawer">
+                  <DrawerContent></DrawerContent>
+                </div>
+              </aside>
+              <div className="content">
+                <main>
+                  <BlogContent
+                    id={blogData.id}
+                    title={blogData.title}
+                    createdAt={blogData.createdAt}
+                    updatedAt={blogData.updatedAt}
+                    content={content}
+                    embedTypes={blogData.embedTypes}
+                  ></BlogContent>
+                </main>
+                <div className="footer">
+                  <Footer></Footer>
+                </div>
+              </div>
+            </div>
+          </div>
+        </DrawerContainer>
+      </Styled>
+    </>
+  );
+};

--- a/src/components/blog-link.tsx
+++ b/src/components/blog-link.tsx
@@ -36,7 +36,7 @@ interface Props {
 export const BlogLink: React.FC<Props> = ({ id, title, createdAt }) => {
   return (
     <Styled>
-      <Link href={`blog/${id}`}>
+      <Link href={`/blog/${id}`}>
         <a className="link">
           <h2 className="title">{title}</h2>
         </a>

--- a/src/components/blog-list.tsx
+++ b/src/components/blog-list.tsx
@@ -1,11 +1,14 @@
+import Link from 'next/link';
 import React from 'react';
 import styled from 'styled-components';
-import { BlogData } from '../models';
+import { BlogData, PagenationInfo } from '../models';
 import { breakPointMedium, breakPointSmall } from '../styles';
 import { BlogLink } from './blog-link';
 
 type Props = {
   blogDataList: BlogData[];
+  pageId: number;
+  pagenationInfo: PagenationInfo;
 };
 
 const Styled = styled.div`
@@ -13,6 +16,10 @@ const Styled = styled.div`
 
   .blog-list {
     padding-top: 10px;
+  }
+
+  .pagenation {
+    display: flex;
   }
 
   @media (max-width: ${breakPointMedium}) {
@@ -25,7 +32,7 @@ const Styled = styled.div`
   }
 `;
 
-export const BlogList: React.FC<Props> = ({ blogDataList }) => {
+export const BlogList: React.FC<Props> = ({ blogDataList, pageId, pagenationInfo }) => {
   return (
     <>
       <Styled>
@@ -34,6 +41,10 @@ export const BlogList: React.FC<Props> = ({ blogDataList }) => {
             <BlogLink key={blogData.id} id={blogData.id} title={blogData.title} createdAt={blogData.createdAt} />
           ))}
         </ul>
+        <div className="pagenation">
+          <div className="pagenation-link-wrapper">{pagenationInfo.hasPrev && <Link href={`/blogs/page/${pageId - 1}`}>Prev</Link>}</div>
+          <div className="pagenation-link-wrapper">{pagenationInfo.hasNext && <Link href={`/blogs/page/${pageId + 1}`}>Next</Link>}</div>
+        </div>
       </Styled>
     </>
   );

--- a/src/components/blog-list.tsx
+++ b/src/components/blog-list.tsx
@@ -12,23 +12,33 @@ type Props = {
 };
 
 const Styled = styled.div`
-  padding: 0 20%;
+  padding: 10px 20% 20px;
 
   .blog-list {
-    padding-top: 10px;
+    padding-inline-start: 0px;
   }
 
   .pagenation {
     display: flex;
+    justify-content: space-between;
+  }
+
+  .pagenation-link-wrapper {
+    font-weight: bold;
+    font-size: 1.2em;
   }
 
   @media (max-width: ${breakPointMedium}) {
-    padding: 0 10%;
+    padding: 10px 10% 20px;
   }
 
   @media (max-width: ${breakPointSmall}) {
-    padding: 0;
+    padding: 10px 4% 20px;
     min-height: 300px;
+
+    .pagenation {
+      padding: 0 8%;
+    }
   }
 `;
 
@@ -42,8 +52,8 @@ export const BlogList: React.FC<Props> = ({ blogDataList, pageId, pagenationInfo
           ))}
         </ul>
         <div className="pagenation">
-          <div className="pagenation-link-wrapper">{pagenationInfo.hasPrev && <Link href={`/blogs/page/${pageId - 1}`}>Prev</Link>}</div>
-          <div className="pagenation-link-wrapper">{pagenationInfo.hasNext && <Link href={`/blogs/page/${pageId + 1}`}>Next</Link>}</div>
+          <div className="pagenation-link-wrapper">{pagenationInfo.hasPrev && <Link href={`/blogs/page/${pageId - 1}`}>←Prev</Link>}</div>
+          <div className="pagenation-link-wrapper">{pagenationInfo.hasNext && <Link href={`/blogs/page/${pageId + 1}`}>→Next</Link>}</div>
         </div>
       </Styled>
     </>

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -51,7 +51,7 @@ export const Menu: React.FC<MenuProps> = ({ route }: MenuProps) => {
               <a>Accounts</a>
             </Link>
           </div>
-          <div className={route === '/blogs' || route === '/blog/[id]' ? 'menu-item selected' : 'menu-item not-selected'}>
+          <div className={route === '/blogs' || route === '/blogs/page/[id]' ? 'menu-item selected' : 'menu-item not-selected'}>
             <Link href="/blogs">
               <a>Blogs</a>
             </Link>

--- a/src/models.ts
+++ b/src/models.ts
@@ -9,3 +9,8 @@ export type BlogData = {
   image?: string;
   embedTypes: EmbedType[];
 };
+
+export interface PagenationInfo {
+  hasNext: boolean;
+  hasPrev: boolean;
+}

--- a/src/pages/blog/[id].tsx
+++ b/src/pages/blog/[id].tsx
@@ -1,128 +1,23 @@
-import { Divider } from '@material-ui/core';
-import MenuIcon from '@material-ui/icons/Menu';
 import { GetStaticPaths, GetStaticProps, NextPage } from 'next';
 import { useRouter } from 'next/router';
-import React, { useCallback, useState } from 'react';
-import styled from 'styled-components';
-import { BlogContent } from '../../components/blog-content';
+import React from 'react';
+import { BlogLayout } from '../../components/blog-layout';
 import { CustomHead } from '../../components/custom-head';
-import { DrawerContainer } from '../../components/drawer-container';
-import { DrawerContent } from '../../components/drawer-content';
-import { Footer } from '../../components/footer';
 import { BlogData } from '../../models';
 import { getAllBlogIds, getBlogData } from '../../repositories/blogs';
-import { breakPointMedium } from '../../styles';
 
 type Props = {
   content: string;
   blogData: BlogData;
 };
 
-const Styled = styled.div`
-  .wrapper {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-  }
-
-  .sp-header {
-    display: none;
-  }
-
-  .drawer-not-sp {
-    width: 240px;
-    flex-shrink: 0;
-  }
-
-  .content-wrapper {
-    display: flex;
-    min-height: 100vh;
-  }
-
-  .pc-drawer-container {
-    border-right: 1px solid #efefef;
-    flex-basis: 16%;
-  }
-
-  .pc-drawer {
-    position: sticky;
-    top: 0px;
-  }
-
-  .content {
-    flex-basis: 84%;
-  }
-
-  @media (max-width: ${breakPointMedium}) {
-    padding: 0 2%;
-
-    .sp-header {
-      display: flex;
-      position: fixed;
-      width: 100%;
-      background: white;
-      z-index: 1;
-    }
-
-    .content-wrapper {
-      margin-top: 24px;
-    }
-
-    .pc-drawer-container {
-      display: none;
-    }
-
-    .content {
-      flex-basis: 100%;
-      overflow: visible;
-      max-width: 100%;
-      word-break: break-word;
-    }
-  }
-`;
-
 const Blog: NextPage<Props> = ({ content, blogData }) => {
   const router = useRouter();
-  const [isSpDrawerOpen, setIsSpDrawerOpen] = useState(false);
-  const changeIsDrawerOpen = useCallback(() => {
-    setIsSpDrawerOpen((prev) => !prev);
-  }, []);
 
   return (
     <>
       <CustomHead title={blogData.title} page={router.asPath} description={blogData.description} type="website"></CustomHead>
-      <Styled>
-        <DrawerContainer isOpen={isSpDrawerOpen} changeSidenav={changeIsDrawerOpen}>
-          <div className="wrapper">
-            <div className="sp-header">
-              <MenuIcon onClick={changeIsDrawerOpen} fontSize="large"></MenuIcon>
-              <Divider></Divider>
-            </div>
-            <div className="content-wrapper">
-              <aside className="pc-drawer-container">
-                <div className="pc-drawer">
-                  <DrawerContent></DrawerContent>
-                </div>
-              </aside>
-              <div className="content">
-                <main>
-                  <BlogContent
-                    id={blogData.id}
-                    title={blogData.title}
-                    createdAt={blogData.createdAt}
-                    updatedAt={blogData.updatedAt}
-                    content={content}
-                    embedTypes={blogData.embedTypes}
-                  ></BlogContent>
-                </main>
-                <div className="footer">
-                  <Footer></Footer>
-                </div>
-              </div>
-            </div>
-          </div>
-        </DrawerContainer>
-      </Styled>
+      <BlogLayout content={content} blogData={blogData}></BlogLayout>
     </>
   );
 };

--- a/src/pages/blogs.tsx
+++ b/src/pages/blogs.tsx
@@ -2,22 +2,28 @@ import React from 'react';
 import { NextPage, GetStaticProps } from 'next';
 import { CustomHead } from '../components/custom-head';
 import { BlogList } from '../components/blog-list';
-import { getSortedBlogsData } from '../repositories/blogs';
-import { BlogData } from '../models';
+import { getPagenatedSortedBlogsData, getPagenationInfo } from '../repositories/blogs';
+import { BlogData, PagenationInfo } from '../models';
 
-const BlogsPage: NextPage<{ blogDataList: BlogData[] }> = ({ blogDataList }) => {
+const BlogsPage: NextPage<{ blogDataList: BlogData[]; pagenationInfo: PagenationInfo; pageId: number }> = ({
+  blogDataList,
+  pagenationInfo,
+  pageId,
+}) => {
   return (
     <>
       <CustomHead title="Blogs" page="/blogs" description="@hxrxchangのブログ一覧" type="website"></CustomHead>
-      <BlogList blogDataList={blogDataList}></BlogList>
+      <BlogList blogDataList={blogDataList} pagenationInfo={pagenationInfo} pageId={pageId}></BlogList>
     </>
   );
 };
 
 export const getStaticProps: GetStaticProps = async () => {
-  const blogDataList = getSortedBlogsData();
+  const pageId = 1;
+  const blogDataList = getPagenatedSortedBlogsData(pageId);
+  const pagenationInfo = getPagenationInfo(pageId);
   return {
-    props: { blogDataList },
+    props: { blogDataList, pagenationInfo, pageId },
   };
 };
 

--- a/src/pages/blogs/page/[id].tsx
+++ b/src/pages/blogs/page/[id].tsx
@@ -2,27 +2,34 @@ import React from 'react';
 import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
 import { CustomHead } from '../../../components/custom-head';
 import { BlogList } from '../../../components/blog-list';
-import { getSortedBlogsData } from '../../../repositories/blogs';
-import { BlogData } from '../../../models';
+import { getBlogsPagePaths, getPagenatedSortedBlogsData, getPagenationInfo } from '../../../repositories/blogs';
+import { BlogData, PagenationInfo } from '../../../models';
 
-const BlogsPage: NextPage<{ blogDataList: BlogData[] }> = ({ blogDataList }) => {
+const BlogsPage: NextPage<{ blogDataList: BlogData[]; pagenationInfo: PagenationInfo; pageId: number }> = ({
+  blogDataList,
+  pagenationInfo,
+  pageId,
+}) => {
   return (
     <>
       <CustomHead title="Blogs" page="/blogs" description="@hxrxchangのブログ一覧" type="website"></CustomHead>
-      <BlogList blogDataList={blogDataList}></BlogList>
+      <BlogList blogDataList={blogDataList} pageId={pageId} pagenationInfo={pagenationInfo}></BlogList>
     </>
   );
 };
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = [{ params: { id: '1' } }];
+  const paths = getBlogsPagePaths();
   return { paths, fallback: false };
 };
 
-export const getStaticProps: GetStaticProps = async () => {
-  const blogDataList = getSortedBlogsData();
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const id = params!.id as string;
+  const pageId = parseInt(id, 10);
+  const blogDataList = getPagenatedSortedBlogsData(pageId);
+  const pagenationInfo = getPagenationInfo(pageId);
   return {
-    props: { blogDataList },
+    props: { blogDataList, pagenationInfo, pageId },
   };
 };
 

--- a/src/pages/blogs/page/[id].tsx
+++ b/src/pages/blogs/page/[id].tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { NextPage, GetStaticProps, GetStaticPaths } from 'next';
+import { CustomHead } from '../../../components/custom-head';
+import { BlogList } from '../../../components/blog-list';
+import { getSortedBlogsData } from '../../../repositories/blogs';
+import { BlogData } from '../../../models';
+
+const BlogsPage: NextPage<{ blogDataList: BlogData[] }> = ({ blogDataList }) => {
+  return (
+    <>
+      <CustomHead title="Blogs" page="/blogs" description="@hxrxchangのブログ一覧" type="website"></CustomHead>
+      <BlogList blogDataList={blogDataList}></BlogList>
+    </>
+  );
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const paths = [{ params: { id: '1' } }];
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async () => {
+  const blogDataList = getSortedBlogsData();
+  return {
+    props: { blogDataList },
+  };
+};
+
+export default BlogsPage;

--- a/src/repositories/blogs.ts
+++ b/src/repositories/blogs.ts
@@ -4,7 +4,7 @@ import matter from 'gray-matter';
 import { BlogData, PagenationInfo } from '../models';
 
 const blogsDirectory = path.join(process.cwd(), '/data-sources/blogs');
-const blogItemLengthPerPage = 2;
+const blogItemLengthPerPage = 10;
 
 export function getPagenatedSortedBlogsData(pageId: number): BlogData[] {
   const sortedBlogData = getSortedBlogsData();
@@ -73,8 +73,8 @@ function getSortedBlogsData(): BlogData[] {
 
 function getPagesLength(): number {
   const allBlogsLength = fs.readdirSync(blogsDirectory).length;
-  const result = Math.floor(allBlogsLength / blogItemLengthPerPage);
+  const quotient = Math.floor(allBlogsLength / blogItemLengthPerPage);
   const remainder = allBlogsLength % blogItemLengthPerPage;
-  const pagesLength = remainder === 0 ? result : result + 1;
+  const pagesLength = remainder === 0 ? quotient : quotient + 1;
   return pagesLength;
 }


### PR DESCRIPTION
## やりたいこと
- `/blogs/page/[id]`のURL形式でページネーションできるように実装


## やったこと
- `pages/blogs/page/[id].tsx` を作成
- pageIdを渡すとそのページに応じたブログ記事を返す関数を実装
  - `id=1`を渡すと、作成日でソートされた全ブログ記事の配列の先頭から10要素目までを返す
  - `id=2`を渡すと、配列の11要素目~20要素目を返す。
- getStaticPathのために、ブログ一覧のページがいくつあるか返す関数を実装
- ブログ一覧ページで次のページがあるか、前のページがあるか判定する関数を実装
  - 全2ページあるとすると、1ページ目の時は次のページはあるが、前のページはない。